### PR TITLE
Fixing addon hook; standardizing on ./addons/* structure.

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -22,9 +22,9 @@ list() {
       "  #y{run} - execute the addon's described behaviour" ""
   else
     describe "" "The following addons are defined for this kit:"
-    for addon in hooks/addon-*; do
-      describe "" "  #Gu{$(echo "$addon" | sed -e 's/.*\/addon\///')}"
-      $addon help | sed -e 's/^/    /'
+    for addon in "${addons[@]}"; do
+      describe "" "  #Gu{$addon}"
+      $GENESIS_ROOT/addons/$addon help | sed -e 's/^/    /'
     done
     echo
   fi
@@ -38,8 +38,8 @@ list)
   ;;
 
 *)
-  if [[ -f "$GENESIS_ROOT/addon/$GENESIS_ADDON_SCRIPT" ]] ; then
-    (cd "$GENESIS_ROOT" && "addon/$GENESIS_ADDON_SCRIPT" run "$@")
+  if [[ -f "$GENESIS_ROOT/addons/$GENESIS_ADDON_SCRIPT" ]] ; then
+    (cd "$GENESIS_ROOT" && "addons/$GENESIS_ADDON_SCRIPT" run "$@")
     exit $?
   else
     echo "Unrecognized addon '$GENESIS_ADDON_SCRIPT'."


### PR DESCRIPTION
When writing addons for a generic kit, I came across this error when setting up some addons:

```
$ genesis do gdc-prod.yml list

Verifying availability of vault 'gdc-prod' (https://192.168.124.12)...ok

Running list addon for gdc-prod

The following addons are defined for this kit:

  hooks/addon-*
/tmp/LCzEOW3KsI/6g_058O5mH/hooks/addon: line 27: hooks/addon-*: No such file or directory
```
I had files in the `addons` folder, not `hooks`. So did a little rearrangement...

```
$ mv addons hooks
$ genesis do gdc-prod.yml list

Verifying availability of vault 'gdc-prod' (https://192.168.124.12)...ok

Running list addon for gdc-prod
```

Even less! Looking at the `addons` script, I think it is in disagreement with itself. Lines 14 and 25 seem to be pointing somewhere else.

Line 14: https://github.com/genesis-community/generic-genesis-kit/blob/main/hooks/addon#L14
Line 25: https://github.com/genesis-community/generic-genesis-kit/blob/main/hooks/addon#L25

Decided that `./addons/<name>` was the intended structure based on existing documentation.
